### PR TITLE
feat: Add Forgot Password Feature

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,11 @@
             android:exported="false"
             android:label="@string/title_activity_sign"
             android:theme="@style/Theme.MyFirstApp" />
+        <activity
+            android:name=".ForgotPasswordActivity"
+            android:exported="false"
+            android:label="@string/title_activity_forgot"
+            android:theme="@style/Theme.MyFirstApp" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/my/first/app/ForgotPasswordActivity.kt
+++ b/app/src/main/java/com/my/first/app/ForgotPasswordActivity.kt
@@ -1,0 +1,130 @@
+package com.my.first.app
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.my.first.app.ui.theme.MyFirstAppTheme
+
+class ForgotPasswordActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            ForgotPasswordScreen()
+        }
+    }
+}
+
+@Composable
+fun ForgotPasswordScreen() {
+    MyFirstAppTheme {
+        Scaffold(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background),
+            containerColor = MaterialTheme.colorScheme.background
+        ) { innerPadding ->
+            BackgroundImage()
+            Column(
+                modifier = Modifier
+                    .padding(innerPadding)
+                    .padding(horizontal = 16.dp, vertical = 24.dp)
+                    .fillMaxSize(),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                ForgotPasswordCard()
+            }
+        }
+    }
+}
+
+@Composable
+fun ForgotPasswordCard() {
+    val email = remember { mutableStateOf("") }
+    val emailError = remember { mutableStateOf<String?>(null) }
+
+    fun validateEmail(): Boolean {
+        return if (email.value.isBlank() || !android.util.Patterns.EMAIL_ADDRESS.matcher(email.value).matches()) {
+            emailError.value = "Adresse email invalide"
+            false
+        } else {
+            emailError.value = null
+            true
+        }
+    }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.cardElevation(12.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "Récuperation de mot de passe",
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.primary,
+                textAlign = TextAlign.Center
+            )
+            OutlinedTextField(
+                value = email.value,
+                onValueChange = { email.value = it },
+                label = { Text("Email") },
+                leadingIcon = { Icon(Icons.Filled.Email, contentDescription = "Email Icon") },
+                modifier = Modifier.fillMaxWidth(),
+                isError = emailError.value != null,
+                placeholder = { Text("Entrez votre email") }
+            )
+            if (emailError.value != null) {
+                Text(text = emailError.value!!, color = MaterialTheme.colorScheme.error, fontSize = 12.sp)
+            }
+            Button(
+                onClick = {
+                    if (validateEmail()) {
+                        // Logique pour envoyer le lien de récupération
+                    }
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(50.dp),
+                shape = RoundedCornerShape(12.dp)
+            ) {
+                Text("Envoyer le lien de récupération")
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
     <string name="app_name">MyFirstApp</string>
     <string name="title_activity_accueil">AccueilActivity</string>
     <string name="title_activity_sign">SignActivity</string>
+    <string name="title_activity_forgot">ForgotActivity</string>
 </resources>


### PR DESCRIPTION
-   Introduce `ForgotPasswordActivity` and `ForgotPasswordScreen`.
-   Implement `ForgotPasswordCard` with email input, validation, and recovery link logic.
-   Add `ForgotPasswordActivity` declaration into `AndroidManifest.xml`.
-   Add label `title_activity_forgot` into `strings.xml` file.